### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TartanAir dataset: AirSim Simulation Dataset for Simultaneous Localization and Mapping
-This repository provides sample codes and scripts for accessing the training and testing data, as well as evaluation tools. Please refer to [TartanAir](http://theairlab.org/tartanair-dataset) for more information about the dataset. 
+This repository provides sample code and scripts for accessing the training and testing data, as well as evaluation tools. Please refer to [TartanAir](http://theairlab.org/tartanair-dataset) for more information about the dataset. 
 You can also reach out to contributors on the associated [AirSim GitHub](https://github.com/microsoft/AirSim).
 
 This dataset was used to train the first generalizable learning-based visual odometry [TartanVO](http://theairlab.org/tartanvo/), which achieved better performance than geometry-based VO methods in challenging cases. Please check out the [paper](https://arxiv.org/pdf/2011.00359.pdf) and published [TartanVO code](https://github.com/castacks/tartanvo). 
@@ -118,7 +118,7 @@ python download_training.py --output-dir OUTPUTDIR --rgb --depth --seg --flow
 ---
 **NOTE**
 
-We found that using AzCopy, which is a tool provided by MicroSoft, is much faster than directly donwloading by the URLs. Please try the following steps if you want to accelerate the downloading process. 
+We found that using AzCopy, which is a tool provided by MicroSoft, is much faster than directly downloading by the URLs. Please try the following steps if you want to accelerate the downloading process. 
 
 1. Download the [AzCopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10) and put the executable to your system path. 
 


### PR DESCRIPTION
1. "code" is a mass noun, so its plural is also "code"; [source](https://english.stackexchange.com/questions/20455/is-it-wrong-to-use-the-word-codes-in-a-programming-context)
2. fix spelling of "downloading"